### PR TITLE
Fix ParticleFilter::updateWeights std_landmark[] argument description

### DIFF
--- a/src/particle_filter.h
+++ b/src/particle_filter.h
@@ -81,8 +81,7 @@ public:
 	 * updateWeights Updates the weights for each particle based on the likelihood of the 
 	 *   observed measurements. 
 	 * @param sensor_range Range [m] of sensor
-	 * @param std_landmark[] Array of dimension 2 [standard deviation of range [m],
-	 *   standard deviation of bearing [rad]]
+	 * @param std_landmark[] Array of dimension 2 [Landmark measurement uncertainty [x [m], y [m]]]
 	 * @param observations Vector of landmark observations
 	 * @param map Map class containing map landmarks
 	 */


### PR DESCRIPTION
A discussion with a fellow student lead us to believe that the description for the `std_landmark[]` argument for `ParticleFilter::updateWeights()` in `particle_filter.h` is incorrect.

Following the logic from lines 43 and 115 of main.cpp
```
double sigma_landmark [2] = {0.3, 0.3}; // Landmark measurement uncertainty [x [m], y [m]]
```
and
```
pf.updateWeights(sensor_range, sigma_landmark, noisy_observations, map);
```
respectively.

This suggests that the std_landmark argument reflects the measurement uncertainties of x and y, not range and bearing.

I hope I have correctly interpreted the ambiguity and that you think this correction is worth merging.