### PR TITLE
Remove nproc (missing on Mac)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,4 +16,4 @@ cd `dirname $0`
 mkdir -p build
 cd build
 cmake ..
-make -j `nproc` $*
+make $*


### PR DESCRIPTION
I would like to suggest this change to avoid a spurious error message on Mac.

When I run `build.sh` on a Mac, I get this error message in the output:
```
./build.sh: line 19: nproc: command not found
```

The build still works, but it is distracting, and I run `build.sh` a lot when working on the project.

The error happens because the `nproc` utility does not exist on Mac. You could replace the call with something like
```
make -j `nproc 2>/dev/null || sysctl -n hw.logicalcpu` $*
```
but that seems overcomplicated.

I think in this case, given that there are only a few small files, and that we will usually only be modifying one of them, it would be better to just drop the `-j` flag and argument altogether for improved portability, so that is what I've proposed here.