### PR TITLE
Fix install-mac script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,24 @@ In this project you will implement a 2 dimensional particle filter in C++. Your 
 ## Running the Code
 This project involves the Term 2 Simulator which can be downloaded [here](https://github.com/udacity/self-driving-car-sim/releases)
 
-This repository includes two files that can be used to set up and intall uWebSocketIO for either Linux or Mac systems. For windows you can use either Docker, VMware, or even Windows 10 Bash on Ubuntu to install uWebSocketIO.
+This repository includes two files that can be used to set up and install uWebSocketIO for either Linux or Mac systems. For windows you can use either Docker, VMware, or even Windows 10 Bash on Ubuntu to install uWebSocketIO.
 
 Once the install for uWebSocketIO is complete, the main program can be built and ran by doing the following from the project top directory.
 
+```bash
 mkdir build
 cd build
 cmake ..
 make
 ./particle_filter
+```
 
-Note that the programs that need to be written to accomplish the project are src/particle_filter.cpp, and particle_filter.h
+Note that the programs that need to be written to accomplish the project are `src/particle_filter.cpp`, and `particle_filter.h`
 
-The program main.cpp has already been filled out, but feel free to modify it.
+The program `main.cpp` has already been filled out, but feel free to modify it.
 
-Here is the main protcol that main.cpp uses for uWebSocketIO in communicating with the simulator.
-
+Here is the main protocol that `main.cpp` uses for uWebSocketIO in communicating with the simulator.
+```
 INPUT: values provided by the simulator to the c++ program
 
 // sense noisy position data from the simulator
@@ -49,8 +51,9 @@ INPUT: values provided by the simulator to the c++ program
 ["sense_observations_x"] 
 
 ["sense_observations_y"] 
+```
 
-
+```
 OUTPUT: values provided by the c++ program to the simulator
 
 // best particle values used for calculating the error evaluation
@@ -72,7 +75,7 @@ OUTPUT: values provided by the c++ program to the simulator
 ["best_particle_sense_x"] <= list of sensed x positions
 
 ["best_particle_sense_y"] <= list of sensed y positions
-
+```
 
 Your job is to build out the methods in `particle_filter.cpp` until the simulator output says:
 

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -1,14 +1,16 @@
+#!/usr/bin/env bash
+
 brew install openssl libuv cmake
 git clone https://github.com/uWebSockets/uWebSockets 
 cd uWebSockets
 git checkout e94b6e1
 patch CMakeLists.txt < ../cmakepatch.txt
 mkdir build
+export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/include/
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig 
 cd build
 cmake ..
 make 
 sudo make install
-cd ..
-cd ..
+cd ../..
 sudo rm -r uWebSockets


### PR DESCRIPTION
`install-mac.sh` script will fail in building `uWebSockets` if `OPENSSL_ROOT_DIR` is not set.