### PR TITLE
Fix build warning on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ include_directories(/usr/local/include)
 include_directories(/usr/local/opt/openssl/include)
 link_directories(/usr/local/lib)
 link_directories(/usr/local/opt/openssl/lib)
-link_directories(/usr/local/Cellar/libuv/1.11.0/lib)
 
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin") 
 


### PR DESCRIPTION
The warning is `ld: warning: directory not found for option
'-L/usr/local/Cellar/libuv/1.11.0/lib'`

It is because the library is installed via homebrew and the homebrew
formula of libuv was upgraded to 1.12.0, and the library is installed
in `/usr/local/Cellar/libuv/1.12.0/`.

However, there is no need to include the path in build config because
symbolic link to the files are added to `/usr/local/lib`, which is
already included.