### PR TITLE
Add Headers to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,11 @@ add_definitions(-std=c++11)
 set(CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
 
-set(sources src/particle_filter.cpp src/main.cpp)
+file(GLOB HEADERS src/*.h)
+file(GLOB HEADERS_HPP src/*.hpp)
+
+set(sources src/particle_filter.cpp src/main.cpp ${HEADERS} ${HEADERS_HPP})
+
 
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin") 


### PR DESCRIPTION
This PR adds all C/C++ headers to the cmake file to let them show up in the file browser of xcode


<img width="255" alt="untitled" src="https://user-images.githubusercontent.com/25514/27994940-06fc3efe-64c7-11e7-9edf-4c8cbeac6bf6.png">
